### PR TITLE
Remove arrow from CA_AB

### DIFF
--- a/mobileapp/android/app/build.gradle
+++ b/mobileapp/android/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.tmrow.electricitymap"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 108900
-        versionName "1.89.0"
+        versionCode 1011300
+        versionName "1.113.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/mobileapp/fastlane/Fastfile
+++ b/mobileapp/fastlane/Fastfile
@@ -5,6 +5,8 @@
 
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
+ios_dir = File.expand_path("../ios")
+android_dir = File.expand_path("../android")
 
 private_lane :build_web_app do
   ensure_env_vars(
@@ -33,7 +35,6 @@ private_lane :increment_package_version do
 end
 
 platform :ios do
-  ios_dir = File.expand_path("../ios")
 
   lane :bump_version do
     version = increment_package_version
@@ -102,7 +103,6 @@ platform :ios do
 end
 
 platform :android do
-  android_dir = File.expand_path("../android")
 
   lane :bump_version do
     version = increment_package_version
@@ -171,6 +171,7 @@ end
 
 desc "Push new version to GitHub"
 lane :commit do
+  prompt(text: "Please switch to master and pull the latest changes. Press y and Enter to continue.")
   git_commit(path: ["./package.json", File.join(ios_dir, "App/App.xcodeproj/project.pbxproj"), File.join(android_dir, "app/build.gradle")], message: "Bumps mobile version")
   # Note: This step requires GitHub admin privileges in order to push directly to master
   push_to_git_remote(

--- a/mobileapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobileapp/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.89.0;
+				CURRENT_PROJECT_VERSION = 1.113.0;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -361,7 +361,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.89.0;
+				MARKETING_VERSION = 1.113.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -380,7 +380,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.89.0;
+				CURRENT_PROJECT_VERSION = 1.113.0;
 				DEVELOPMENT_TEAM = MP3LBAUPG8;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Electricity Maps";
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.89.0;
+				MARKETING_VERSION = 1.113.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tmrow.electricitymap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electricitymaps-mobile",
-  "version": "1.89.0",
+  "version": "1.113.0",
   "description": "A real-time visualisation of the CO2 emissions of electricity consumption",
   "license": "AGPL-3.0-or-later",
   "main": "index.js",


### PR DESCRIPTION
## Issue
#6135

<!-- If you want to close an issue automatically when your PR is merged, write "Closes X" where X is the PR number. For example: Closes #000 -->

## Description
Removes arrow module from parser, replacing with `datetime`.
<!-- Explains the goal of this PR -->

### Preview

<!-- Please add screenshots and/or gif that shows visual changes (if applicable) -->

### Double check

- [ ] I have tested my parser changes locally with `poetry run test_parser "zone_key"`
- [ ] I have run `pnpx prettier@2 --write .` and `poetry run format` in the top level directory to format my changes.
